### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 A docker implementation of [ExtentX](https://github.com/anshooarora/extentx).
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/XhfFiVtGMXhfiynNYZxdsCvP/email2vimalraj/docker-extentx'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/XhfFiVtGMXhfiynNYZxdsCvP/email2vimalraj/docker-extentx.svg' />
-</a>
+
 
 ## Installation
 1. Clone this repository


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8